### PR TITLE
TestCase uses class alias

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,8 +3,9 @@
 namespace CornellCustomDev\LaravelStarterKit\Tests;
 
 use CornellCustomDev\LaravelStarterKit\StarterKitServiceProvider;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
-class TestCase extends \Orchestra\Testbench\TestCase
+class TestCase extends OrchestraTestCase
 {
     public function setUp(): void
     {


### PR DESCRIPTION
Increases readability by avoiding having a full namespace in the `extends` statement.

**This PR does the following**

- Closes #44 

**To Review:**

- [ ] Code review