### PR TITLE
Livewire 3 + Laravel 10

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,8 +9,8 @@ jobs:
         php: [8.1]
         stability: [prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
+          - laravel: 10.*
+            testbench: 8.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
     steps:

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "library",
   "require": {
     "php": "^8.1",
-    "livewire/livewire": "^2.10",
+    "livewire/livewire": "^3.0@beta",
     "spatie/laravel-package-tools": "^1.13",
     "cubear/cwd_framework_lite": "^3.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,14 @@
   "type": "library",
   "require": {
     "php": "^8.1",
-    "livewire/livewire": "^3.0@beta",
-    "spatie/laravel-package-tools": "^1.13",
+    "livewire/livewire": "^3.3",
+    "spatie/laravel-package-tools": "^1.16",
     "cubear/cwd_framework_lite": "^3.0"
   },
   "require-dev": {
-    "orchestra/testbench": "^7.0",
-    "phpunit/phpunit": "^9.5",
-    "laravel/pint": "^1.2"
+    "orchestra/testbench": "^8.17",
+    "phpunit/phpunit": "^10.5",
+    "laravel/pint": "^1.13"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,15 +3,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     bootstrap="vendor/autoload.php"
     colors="true"
-    verbose="true"
     testdox="true"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    cacheDirectory=".phpunit.cache"
 >
-    <coverage>
+    <source>
         <include>
-            <directory suffix=".php">src/</directory>
+            <directory>src/</directory>
         </include>
-    </coverage>
+    </source>
     <testsuites>
         <testsuite name="Unit">
             <directory>./tests/Unit</directory>

--- a/src/StarterKitServiceProvider.php
+++ b/src/StarterKitServiceProvider.php
@@ -111,7 +111,7 @@ class StarterKitServiceProvider extends PackageServiceProvider
         );
     }
 
-    public static function populatePlaceholders($files, string $projectName, string $projectDescription = null): void
+    public static function populatePlaceholders($files, string $projectName, ?string $projectDescription = null): void
     {
         $replacements = [
             ':project_name' => $projectName,


### PR DESCRIPTION
Updates Livewire to v3.3, which also requires Laravel framework v10 (via orchestra/testbench v8)

**This PR does the following**

- Composer requires Livewire

**To Review:**

- [ ] Confirm passes automated tests (via GitHub actions)