### PR TITLE
Adjust some settings for better installs

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -2,7 +2,7 @@ name: cd-laravelstarterkit
 recipe: laravel
 config:
   webroot: ./public
-  php: 8.1
+  php: 8.2
   composer_version: 2-latest
 
 tooling:

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,6 @@
       ]
     }
   },
-  "minimum-stability": "dev",
+  "minimum-stability": "stable",
   "prefer-stable": true
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,7 @@
     bootstrap="vendor/autoload.php"
     colors="true"
     testdox="true"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     cacheDirectory=".phpunit.cache"
 >
     <source>

--- a/project/.env.example
+++ b/project/.env.example
@@ -1,5 +1,5 @@
 APP_NAME=":project_name"
-APP_ENV=testing
+APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=https://:project_slug
@@ -23,7 +23,7 @@ SESSION_DRIVER=file
 SESSION_LIFETIME=120
 
 MAIL_MAILER=log
-MAIL_HOST=mailhog
+MAIL_HOST=mailpit
 MAIL_PORT=1025
 MAIL_USERNAME=null
 MAIL_PASSWORD=null

--- a/project/.gitignore
+++ b/project/.gitignore
@@ -1,3 +1,4 @@
+/.phpunit.cache
 /node_modules
 /public/build
 /public/hot

--- a/project/.lando.yml
+++ b/project/.lando.yml
@@ -2,5 +2,5 @@ name: :project_slug
 recipe: laravel
 config:
   webroot: ./public
-  php: 8.1
+  php: 8.2
   composer_version: 2-latest


### PR DESCRIPTION
When I went to use v0.3.0 of the StarterKit I ran into a couple install / config issues. This addresses them.

This is mostly a pro-forma review, as I've tested these fixes on a Laravel 10 demo site.

**This PR does the following**

- Sets composer minimum-stability to "stable" so we don't pull in dev versions of dependencies
- Adjusts project .gitignore, .env.example, .lando.yml to be current
- Uses improved phpunit.xml

**To Review:**

- [ ] Code review